### PR TITLE
Review GitHub Actions for outdated versions

### DIFF
--- a/.github/workflows/go-build-deploy.yml
+++ b/.github/workflows/go-build-deploy.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.25'
 
@@ -25,7 +25,7 @@ jobs:
       run: ./debugjois.dev build
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -12,9 +12,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.25'
 

--- a/.github/workflows/sync-build-deploy.yml
+++ b/.github/workflows/sync-build-deploy.yml
@@ -15,9 +15,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.25'
 
@@ -37,7 +37,7 @@ jobs:
         GDRIVE_FOLDER_ID: ${{ secrets.GDRIVE_FOLDER_ID }}
 
     - name: Commit to Github Repo
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "GDrive Obsidian Vault Sync"
 
@@ -45,7 +45,7 @@ jobs:
       run: ./debugjois.dev build
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v5
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
- actions/checkout: v4 -> v5 (updated to Node 24)
- actions/setup-go: v5 -> v6 (improved caching)
- aws-actions/configure-aws-credentials: v4 -> v5 (timeout & no-proxy support)
- stefanzweifel/git-auto-commit-action: v5 -> v7 (semantic versioning)