### PR TITLE
Simplify Dependabot workflow for Go project

### DIFF
--- a/.github/workflows/dependabot-build-check.yml
+++ b/.github/workflows/dependabot-build-check.yml
@@ -1,0 +1,31 @@
+name: Dependabot Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    # Only run if the PR is from Dependabot
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Build Go project
+        run: |
+          echo "Building Go project..."
+          go build ./...
+          if [ $? -ne 0 ]; then
+            echo "Go build failed!"
+            exit 1
+          fi
+          echo "Go build successful!"


### PR DESCRIPTION
- Removes Node.js setup and build steps (not needed for this Go-only project)
- Uses Go 1.25 to match existing workflows
- Only runs for dependabot PRs
- Verifies Go build passes without running binary subcommands
- Uses latest action versions (checkout@v6, setup-go@v6)