### PR TITLE
ci: fix local action - checkout must precede uses of local action

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -1,11 +1,9 @@
 name: Setup Go and Build
-description: Checkout repo, set up Go version from go.mod, and compile the project
+description: Set up Go version from go.mod and compile the project (checkout must happen before calling this action)
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-
     - uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'

--- a/.github/workflows/dependabot-build-check.yml
+++ b/.github/workflows/dependabot-build-check.yml
@@ -12,4 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v6
+
       - uses: ./.github/actions/setup-and-build

--- a/.github/workflows/go-build-deploy.yml
+++ b/.github/workflows/go-build-deploy.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v6
+
     - uses: ./.github/actions/setup-and-build
 
     - name: Restore build cache

--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -12,6 +12,8 @@ jobs:
       contents: read
 
     steps:
+    - uses: actions/checkout@v6
+
     - uses: ./.github/actions/setup-and-build
 
     - name: Post to Buttondown

--- a/.github/workflows/sync-build-deploy.yml
+++ b/.github/workflows/sync-build-deploy.yml
@@ -15,6 +15,8 @@ jobs:
       contents: write
 
     steps:
+    - uses: actions/checkout@v6
+
     - uses: ./.github/actions/setup-and-build
 
     - name: Create credentials.json


### PR DESCRIPTION
GitHub Actions resolves local composite actions relative to the checked-out workspace, so the repo must already be on disk before the runner can find action.yml. Moved checkout back into each workflow as the first step and removed it from the composite action.

https://claude.ai/code/session_01MJYZTEboQKuBBTGN79ev56