### PR TITLE
Restore dependabot for GitHub Actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Re-adds dependabot.yml with only the github-actions ecosystem to keep
Actions and workflow dependencies up to date. Go module updates are
handled separately by the latest-deps workflow.

https://claude.ai/code/session_01BksdZVnFiuzCeQpUBHexmi