### PR TITLE
Upgrade Go version to 1.26.1

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/deepakjois/debugjois.dev
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/alecthomas/kong v1.14.0


### PR DESCRIPTION
## Summary
Updates the Go version requirement for the project from 1.26.0 to 1.26.1.

## Changes
- Updated `go.mod` to specify Go 1.26.1 as the minimum required version

## Details
This is a patch version upgrade that ensures the project uses the latest stable Go 1.26 release, which may include bug fixes and security improvements.

https://claude.ai/code/session_01JkdY967gYs2cy2UKgNtPsY